### PR TITLE
fix: add caching logic for bottom detail view to prevent collapsing

### DIFF
--- a/Logger/Models/EventModel.swift
+++ b/Logger/Models/EventModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 
-struct EventModel: Identifiable {
+struct EventModel: Identifiable, Equatable {
     struct ParsingKeys {
         static let category = "category"
         static let subsystem = "subsystem"
@@ -87,6 +87,7 @@ struct EventModel: Identifiable {
 
     static func == (lhs: EventModel,
                     rhs: EventModel) -> Bool {
+        
         return lhs.id == rhs.id &&
             lhs.category == rhs.category &&
             lhs.subsystem == rhs.subsystem &&

--- a/Logger/Views/BottomDetailView/BottomDetailView.swift
+++ b/Logger/Views/BottomDetailView/BottomDetailView.swift
@@ -7,16 +7,34 @@
 
 import SwiftUI
 
+var cachedDetailsList: DetailsList?
+var cachedModel: EventModel?
+
 struct BottomDetailView: View {
     @ObservedObject var loggerViewModel: LoggerViewModel
     var body: some View {
-        VStack {
-            if let model = loggerViewModel.getModelSelected() {
-                DetailsList(items: loggerViewModel.dataModels(from: model))
-            }
+        return VStack {
+            getDetailListComponent()
         }.frame(maxWidth: .infinity,
                 maxHeight: .infinity)
             .background(Color(ColorKeys.BottomDetailViewColor))
+    }
+
+    
+    /// It returns new or cached details list component. It needed to prevent collapsing in case rerender same event model
+    func getDetailListComponent() -> DetailsList? {
+        if let model = loggerViewModel.getModelSelected() {
+            if let cachedModel = cachedModel,
+               cachedModel == model {
+            } else {
+                cachedDetailsList = DetailsList(items: loggerViewModel.dataModels(from: model))
+                cachedModel = model
+            }
+        } else {
+            cachedModel = nil
+            cachedDetailsList = nil
+        }
+        return cachedDetailsList
     }
 }
 


### PR DESCRIPTION
Add caching logic for bottom detail view to prevent collapsing. In case when new events coming selected event data starts to collapse list component because of creation new detail view